### PR TITLE
Remove filtering for success in util funcs

### DIFF
--- a/push_action/utils.py
+++ b/push_action/utils.py
@@ -178,9 +178,7 @@ def get_required_actions(statuses: List[str], new_request: bool = False) -> List
                 jobs.extend(get_workflow_run_jobs(run["id"]))
 
             IN_MEMORY_CACHE[cache_name] = [
-                _
-                for _ in jobs
-                if _.get("name", "") in statuses and _.get("status", "") != "completed"
+                _ for _ in jobs if _.get("name", "") in statuses
             ]
 
     return IN_MEMORY_CACHE[cache_name]


### PR DESCRIPTION
Now that the `branch` query parameter is used to retrieve Actions, the list of required Actions should not be filtered for `success` in the utility function `get_required_actions()`.