### PR TITLE
Add `sleep` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         branch: not_protected
         changes: .github/workflows/ci.sh
         extra_data: .github/extra_data.log,.github/workflows/extra_data_more.md
-        sleep: 0
+        sleep: 4
 
   protected:
     needs: reset_test_branches
@@ -72,4 +72,4 @@ jobs:
         branch: protected
         changes: .github/workflows/ci.sh
         extra_data: .github/extra_data.log,.github/workflows/extra_data_more.md
-        sleep: 0
+        sleep: 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         changes: .github/workflows/ci.sh
         extra_data: .github/extra_data.log,.github/workflows/extra_data_more.md
         sleep: 4
-        unprotect reviews: true
+        unprotect_reviews: true
 
   protected:
     needs: reset_test_branches
@@ -74,4 +74,4 @@ jobs:
         changes: .github/workflows/ci.sh
         extra_data: .github/extra_data.log,.github/workflows/extra_data_more.md
         sleep: 4
-        unprotect reviews: true
+        unprotect_reviews: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         branch: not_protected
         changes: .github/workflows/ci.sh
         extra_data: .github/extra_data.log,.github/workflows/extra_data_more.md
+        sleep: 0
 
   protected:
     needs: reset_test_branches
@@ -71,3 +72,4 @@ jobs:
         branch: protected
         changes: .github/workflows/ci.sh
         extra_data: .github/extra_data.log,.github/workflows/extra_data_more.md
+        sleep: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         changes: .github/workflows/ci.sh
         extra_data: .github/extra_data.log,.github/workflows/extra_data_more.md
         sleep: 4
+        unprotect reviews: true
 
   protected:
     needs: reset_test_branches
@@ -73,3 +74,4 @@ jobs:
         changes: .github/workflows/ci.sh
         extra_data: .github/extra_data.log,.github/workflows/extra_data_more.md
         sleep: 4
+        unprotect reviews: true

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ It is recommended to not add unneccessary scopes to a PAT that are not needed fo
 | `interval` | Time interval (in seconds) between each new check, when waiting for status checks to complete. | `False` | `30` |
 | `timeout` | Time (in minutes) of how long the action should run before timing out, waiting for status checks to complete. | `False` | `15` |
 | `sleep` | Time (in seconds) the action should wait until it will start "waiting" and check the list of running actions/checks. This should be an appropriate number to let the checks start up. | `False` | `5` |
+| `unprotect reviews` | Momentarily remove pull request review protection from target branch. | `False` | `False` |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ It is recommended to not add unneccessary scopes to a PAT that are not needed fo
 | **`token`** | Token for the repo.<br>Used for authentication and starting 'push' hooks. See above for notes on this input. | `True` | |
 | `repository` | Repository name to push to.<br>Default or empty value represents current github repository. | `False` | `${{ github.repository }}` |
 | `branch` | Target branch for the push. | `False` | `master` |
-| `changes` | Shell script to run in the target repository root prior to the push.<br>NOTE: Unrelated to prior workflow jobs and steps. MUST be a file in the repository that spawns the workflow. MUST be a relative path from the repository root, e.g., `.github/workflows/changes.sh`. | `False` | `` |
-| `extra_data` | Comma-separated (,) list of files needed by the shell scipt in `changes`.<br>MUST be a relative path from the repository root, e.g., `.github/workflows/data.md,CHANGLOG.md`.<br>Note, when running the script from `changes`, all these files are in _the same directory_. | `False` | `` |
+| `changes` | Shell script to run in the target repository root prior to the push.<br>NOTE: Unrelated to prior workflow jobs and steps. MUST be a file in the repository that spawns the workflow. MUST be a relative path from the repository root, e.g., `.github/workflows/changes.sh`. | `False` | |
+| `extra_data` | Comma-separated (,) list of files needed by the shell scipt in `changes`.<br>MUST be a relative path from the repository root, e.g., `.github/workflows/data.md,CHANGLOG.md`.<br>Note, when running the script from `changes`, all these files are in _the same directory_. | `False` | |
 | `interval` | Time interval (in seconds) between each new check, when waiting for status checks to complete. | `False` | `30` |
 | `timeout` | Time (in minutes) of how long the action should run before timing out, waiting for status checks to complete. | `False` | `15` |
+| `sleep` | Time (in seconds) the action should wait until it will start "waiting" and check the list of running actions/checks. This should be an appropriate number to let the checks start up. | `False` | `5` |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It is recommended to not add unneccessary scopes to a PAT that are not needed fo
 | `interval` | Time interval (in seconds) between each new check, when waiting for status checks to complete. | `False` | `30` |
 | `timeout` | Time (in minutes) of how long the action should run before timing out, waiting for status checks to complete. | `False` | `15` |
 | `sleep` | Time (in seconds) the action should wait until it will start "waiting" and check the list of running actions/checks. This should be an appropriate number to let the checks start up. | `False` | `5` |
-| `unprotect reviews` | Momentarily remove pull request review protection from target branch. | `False` | `False` |
+| `unprotect_reviews` | Momentarily remove pull request review protection from target branch. | `False` | `False` |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     description: 'Time (in seconds) the action should wait until it will start "waiting" and check the list of running actions/checks. This should be an appropriate number to let the checks start up'
     required: false
     default: 5
-  unprotect reviews:
+  unprotect_reviews:
     description: 'Momentarily remove pull request review protection from target branch'
     required: false
     default: false

--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,13 @@ inputs:
     required: false
     default: 15
   sleep:
-    description: 'Time (in seconds) the action should wait until it will start "waiting" and check the list of running actions/checks. This should be an appropriate number to let the checks start up.'
+    description: 'Time (in seconds) the action should wait until it will start "waiting" and check the list of running actions/checks. This should be an appropriate number to let the checks start up'
     required: false
-    defualt: 5
+    default: 5
+  unprotect reviews:
+    description: 'Momentarily remove pull request review protection from target branch'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Time (in minutes) of how long the action should run before timing out, waiting for status checks to complete'
     required: false
     default: 15
+  sleep:
+    description: 'Time (in seconds) the action should wait until it will start "waiting" and check the list of running actions/checks. This should be an appropriate number to let the checks start up.'
+    required: false
+    defualt: 5
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,7 @@ echo "Creating temporary repository '${TEMPORARY_BRANCH}' ... DONE!"
     # Wait for status checks to complete
     echo "Waiting for status checks to finish for '${TEMPORARY_BRANCH}' ..." &&
     # Sleep for 5 seconds to let the workflows start
-    sleep 5 &&
+    sleep ${INPUT_SLEEP} &&
     push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" --wait-timeout "${INPUT_TIMEOUT}" --wait-interval "${INPUT_INTERVAL}" -- wait_for_checks &&
     echo "Waiting for status checks to finish for '${TEMPORARY_BRANCH}' ... DONE!" &&
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,14 +41,14 @@ git push -f origin ${TEMPORARY_BRANCH}
 echo "Creating temporary repository '${TEMPORARY_BRANCH}' ... DONE!"
 
 # Unprotect/protect functions
-unprotect(){
+unprotect () {
     if [ -n "${INPUT_UNPROTECT_REVIEWS}" ]; then
         echo "Remove '${INPUT_BRANCH}' pull request review protection ..."
         push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- unprotect_reviews
         echo "Remove '${INPUT_BRANCH}' pull request review protection ... DONE!"
     fi
 }
-protect(){
+protect () {
     if [ -n "${INPUT_UNPROTECT_REVIEWS}" ]; then
         echo "Re-add '${INPUT_BRANCH}' pull request review protection ..."
         push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- protect_reviews
@@ -65,7 +65,7 @@ protect(){
     echo "Waiting for status checks to finish for '${TEMPORARY_BRANCH}' ... DONE!" &&
 
     # Unprotect target branch for pull request reviews (if desired)
-    unprotect()
+    unprotect &&
 
     # Merge into target branch
     echo "Merging (fast-forward) '${TEMPORARY_BRANCH}' -> '${INPUT_BRANCH}' ..." &&
@@ -75,7 +75,7 @@ protect(){
     echo "Merging (fast-forward) '${TEMPORARY_BRANCH}' -> '${INPUT_BRANCH}' ... DONE!" &&
 
     # Re-protect target branch for pull request reviews (if desired)
-    protect()
+    protect &&
 
     # Remove temporary repository
     echo "Removing temporary branch '${TEMPORARY_BRANCH}' ..." &&

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,22 @@ git checkout -f -b ${TEMPORARY_BRANCH}
 git push -f origin ${TEMPORARY_BRANCH}
 echo "Creating temporary repository '${TEMPORARY_BRANCH}' ... DONE!"
 
+# Unprotect/protect functions
+unprotect(){
+    if [ -n "${INPUT_UNPROTECT_REVIEWS}" ]; then
+        echo "Remove '${INPUT_BRANCH}' pull request review protection ..."
+        push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- unprotect_reviews
+        echo "Remove '${INPUT_BRANCH}' pull request review protection ... DONE!"
+    fi
+}
+protect(){
+    if [ -n "${INPUT_UNPROTECT_REVIEWS}" ]; then
+        echo "Re-add '${INPUT_BRANCH}' pull request review protection ..."
+        push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- protect_reviews
+        echo "Re-add '${INPUT_BRANCH}' pull request review protection ... DONE!"
+    fi
+}
+
 {
     # Wait for status checks to complete
     echo "Waiting for status checks to finish for '${TEMPORARY_BRANCH}' ..." &&
@@ -49,11 +65,7 @@ echo "Creating temporary repository '${TEMPORARY_BRANCH}' ... DONE!"
     echo "Waiting for status checks to finish for '${TEMPORARY_BRANCH}' ... DONE!" &&
 
     # Unprotect target branch for pull request reviews (if desired)
-    if [ -n "${INPUT_UNPROTECT_REVIEWS}" ]; then
-        echo "Remove '${INPUT_BRANCH}' pull request review protection ..." &&
-        push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- unprotect_reviews &&
-        echo "Remove '${INPUT_BRANCH}' pull request review protection ... DONE!" &&
-    fi &&
+    unprotect()
 
     # Merge into target branch
     echo "Merging (fast-forward) '${TEMPORARY_BRANCH}' -> '${INPUT_BRANCH}' ..." &&
@@ -63,11 +75,7 @@ echo "Creating temporary repository '${TEMPORARY_BRANCH}' ... DONE!"
     echo "Merging (fast-forward) '${TEMPORARY_BRANCH}' -> '${INPUT_BRANCH}' ... DONE!" &&
 
     # Re-protect target branch for pull request reviews (if desired)
-    if [ -n "${INPUT_UNPROTECT_REVIEWS}" ]; then
-        echo "Re-add '${INPUT_BRANCH}' pull request review protection ..." &&
-        push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- protect_reviews &&
-        echo "Re-add '${INPUT_BRANCH}' pull request review protection ... DONE!" &&
-    fi &&
+    protect()
 
     # Remove temporary repository
     echo "Removing temporary branch '${TEMPORARY_BRANCH}' ..." &&

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ echo "Creating temporary repository '${TEMPORARY_BRANCH}' ... DONE!"
         echo "Remove '${INPUT_BRANCH}' pull request review protection ..." &&
         push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- unprotect_reviews &&
         echo "Remove '${INPUT_BRANCH}' pull request review protection ... DONE!" &&
-    fi
+    fi &&
 
     # Merge into target branch
     echo "Merging (fast-forward) '${TEMPORARY_BRANCH}' -> '${INPUT_BRANCH}' ..." &&
@@ -67,7 +67,7 @@ echo "Creating temporary repository '${TEMPORARY_BRANCH}' ... DONE!"
         echo "Re-add '${INPUT_BRANCH}' pull request review protection ..." &&
         push-action --token "${INPUT_TOKEN}" --repo "${INPUT_REPOSITORY}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- protect_reviews &&
         echo "Re-add '${INPUT_BRANCH}' pull request review protection ... DONE!" &&
-    fi
+    fi &&
 
     # Remove temporary repository
     echo "Removing temporary branch '${TEMPORARY_BRANCH}' ..." &&


### PR DESCRIPTION
Make the `sleep` command prior to "waiting" editable as an action option.

Also, add the `unprotect reviews` option, to momentarily remove pull request reviews protection for target branch before merging in the temporary branch.
The pull request reviews protection settings is saved and re-added after merging in the temporary branch.