### PR TITLE
New release workflow

### DIFF
--- a/.github/static/major_version_tag_msg.txt
+++ b/.github/static/major_version_tag_msg.txt
@@ -1,0 +1,3 @@
+vMAJOR
+
+Tag pointing to the latest vMAJOR.x.y version.

--- a/.github/static/release_tag_msg.txt
+++ b/.github/static/release_tag_msg.txt
@@ -1,0 +1,3 @@
+TAG_NAME
+
+This tag was created using the publish GitHub Actions workflow.

--- a/.github/static/update_version.sh
+++ b/.github/static/update_version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+echo -e "\n### Setting commit user ###"
+git config --local user.email "casper+github@welzel.nu"
+git config --local user.name "CasperWA"
+
+echo -e "\n### Update version in README ###"
+invoke update-version --version="${GITHUB_REF#refs/tags/}"
+
+echo -e "\n### Commit update ###"
+git commit -am "Release ${GITHUB_REF#refs/tags/}"
+
+echo -e "\n### Create new full version (v<MAJOR>.<MINOR>.<PATCH>) tag ###"
+TAG_MSG=.github/static/release_tag_msg.txt
+sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|g" "${TAG_MSG}"
+
+git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
+
+echo -e "\n### Move/update v<MAJOR> tag ###"
+MAJOR_VERSION=$( echo ${GITHUB_REF#refs/tags/v} | cut -d "." -f 1 )
+TAG_MSG=.github/static/major_version_tag_msg.txt
+sed -i "s|MAJOR|${MAJOR_VERSION}|g" "${TAG_MSG}"
+
+git tag -af -F "${TAG_MSG}" v${MAJOR_VERSION}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release - updating vMAJOR tag
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'CasperWA/push-protected' && startsWith(github.ref, 'refs/tags/v')
+    env:
+      PUBLISH_UPDATE_BRANCH: master
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Update Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements_dev.txt
+
+    - name: Update version and tags
+      run: .github/static/update_version.sh
+
+    - name: Push updates to '${{ env.PUBLISH_UPDATE_BRANCH }}'
+      uses: ./
+      with:
+        token: ${{ secrets.CI_RESET_TEST_BRANCHES }}
+        branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        force: true
+        tags: true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,2 @@
+invoke~=1.4
 pre-commit~=2.7

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import re
+import sys
+from typing import Tuple
+
+try:
+    from invoke import task
+except ImportError:
+    sys.exit("'invoke' MUST be installed to run these tasks.")
+
+
+TOP_DIR = Path(__file__).parent.resolve()
+
+
+def update_file(filename: str, sub_line: Tuple[str, str], strip: str = None):
+    """Utility function for tasks to read, update, and write files"""
+    with open(filename, "r") as handle:
+        lines = [
+            re.sub(sub_line[0], sub_line[1], line.rstrip(strip)) for line in handle
+        ]
+
+    with open(filename, "w") as handle:
+        handle.write("\n".join(lines))
+        handle.write("\n")
+
+
+@task(help={"version": "push_action package version to set"})
+def update_version(_, version=""):
+    """Update push_action package version"""
+    if version:
+        if version.startswith("v"):
+            version = version[1:]
+        if re.match(r"[0-9]+(\.[0-9]+){2}.*", version) is None:
+            sys.exit(
+                f"Error: Passed `version` ([v]{version}) does to match SemVer versioning."
+            )
+    else:
+        sys.exit("No `version` provided.")
+
+    update_file(
+        TOP_DIR.joinpath("push_action/__init__.py"),
+        (r"__version__ = .+", f'__version__ = "{version}"'),
+    )
+
+    print(f"Bumped version to {version} !")


### PR DESCRIPTION
The new workflow will run on publishing a new release version.

It will run `invoke update-version` passing the tag name of the new
release, which will update `push_action/__init__.py:__version__`.
Then, it will proceed to commit this change, update the newly created
tag, as well as update the `vMAJOR` tag to this newly created commit.

Finally, it will use the local action to push to `master`.