### PR TITLE
Remove use of `global`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ protect () {
     case ${INPUT_UNPROTECT_REVIEWS} in
         y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
             if [ -n "${PROTECTED_BRANCH}" ]; then
-                echo "Re-add '${INPUT_BRANCH}' pull request review protection ..."
+                echo -e "\nRe-add '${INPUT_BRANCH}' pull request review protection ..."
                 push-action --token "${INPUT_TOKEN}" --ref "${INPUT_BRANCH}" --temp-branch "${TEMPORARY_BRANCH}" -- protect_reviews
                 echo "Re-add '${INPUT_BRANCH}' pull request review protection ... DONE!"
             fi

--- a/push_action/cache.py
+++ b/push_action/cache.py
@@ -1,0 +1,48 @@
+from typing import Any, Iterator, Union
+
+
+class InMemoryCache:
+    """In-memory key-value cache"""
+
+    def __len__(self):
+        """Number of cached keys"""
+        return len(self.__dict__)
+
+    def __getitem__(self, key: Union[str, int]) -> Any:
+        """Get cached value, example: `self[key]`"""
+        if not isinstance(key, (str, int)):
+            raise TypeError("Supplied key must be a string or integer.")
+        if key not in self.__dict__:
+            raise KeyError(f"{key!r} not found in cache.")
+        return self.__dict__[key]
+
+    def __setitem__(self, key: Union[str, int], value: Any) -> None:
+        """Set cached value, example: `self[key] = value`"""
+        if not isinstance(key, (str, int)):
+            raise TypeError("Supplied key must be a string or integer.")
+        self.__dict__[key] = value
+
+    def __delitem__(self, key: Union[str, int]) -> None:
+        """Delete cached value, example: `del self[key]`"""
+        if not isinstance(key, (str, int)):
+            raise TypeError("Supplied key must be a string or integer.")
+        if key not in self.__dict__:
+            raise KeyError(f"{key!r} not found in cache.")
+        del self.__dict__[key]
+
+    def __iter__(self) -> Iterator:
+        """Iterate over the cached keys"""
+        return iter(self.__dict__.keys())
+
+    def __contains__(self, item: Union[str, int]) -> bool:
+        """Whether item is cached or not"""
+        if not isinstance(item, (str, int)):
+            raise TypeError("Item must be a string or integer.")
+        return item in self.__dict__.keys()
+
+    def get(self, key: Union[str, int], fallback: Any = None) -> Any:
+        """Get cached value from key"""
+        return self.__dict__.get(key, fallback)
+
+
+IN_MEMORY_CACHE = InMemoryCache()

--- a/push_action/run.py
+++ b/push_action/run.py
@@ -4,13 +4,13 @@ import os
 import sys
 from time import sleep, time
 
+from push_action.cache import IN_MEMORY_CACHE
 from push_action.utils import (
     api_request,
     get_branch_statuses,
     get_required_actions,
     get_required_checks,
     get_workflow_run_jobs,
-    IN_MEMORY_CACHE,
     remove_branch,
 )
 
@@ -192,7 +192,6 @@ def main() -> None:
         ],
     )
 
-    global IN_MEMORY_CACHE
     IN_MEMORY_CACHE["args"] = parser.parse_args()
 
     fail = False
@@ -211,8 +210,6 @@ def main() -> None:
             raise RuntimeError(f"Unknown ACTIONS {IN_MEMORY_CACHE['args'].ACTION!r}")
     except RuntimeError as exc:
         fail = f"{exc.__class__.__name__}: {exc}"
-    finally:
-        del IN_MEMORY_CACHE
 
     if fail:
         sys.exit(fail)

--- a/push_action/utils.py
+++ b/push_action/utils.py
@@ -9,7 +9,9 @@ except ImportError:
 
 import requests
 
-IN_MEMORY_CACHE = {}
+from push_action.cache import IN_MEMORY_CACHE
+
+
 REQUEST_TIMEOUT = 10  # in seconds
 API_V3_BASE = "https://api.github.com"
 
@@ -100,7 +102,6 @@ def get_branch_statuses(name: str, new_request: bool = False) -> List[str]:
 
     These may be GitHub Actions jobs and/or third-party status checks.
     """
-    global IN_MEMORY_CACHE
     cache_name = "get_branch_statuses"
 
     if cache_name not in IN_MEMORY_CACHE or new_request:
@@ -123,7 +124,6 @@ def get_branch_statuses(name: str, new_request: bool = False) -> List[str]:
 
 def get_workflow_runs(workflow_id: int, new_request: bool = False) -> List[dict]:
     """Return list of GitHub Actions workflow runs"""
-    global IN_MEMORY_CACHE
     cache_name = "get_workflow_runs"
 
     if (
@@ -148,7 +148,6 @@ def get_workflow_runs(workflow_id: int, new_request: bool = False) -> List[dict]
 
 def get_workflow_run_jobs(run_id: int, new_request: bool = False) -> List[dict]:
     """Return list of GitHub Actions workflow runs"""
-    global IN_MEMORY_CACHE
     cache_name = "get_workflow_run_jobs"
 
     if (
@@ -171,7 +170,6 @@ def get_workflow_run_jobs(run_id: int, new_request: bool = False) -> List[dict]:
 
 def get_required_actions(statuses: List[str], new_request: bool = False) -> List[dict]:
     """Get subset of statuses that belong to GitHub Actions jobs"""
-    global IN_MEMORY_CACHE
     cache_name = "get_required_actions"
 
     if cache_name not in IN_MEMORY_CACHE or new_request:


### PR DESCRIPTION
Create a class in the new `cache.py` file, which emulates a mapping container.
An instance named `IN_MEMORY_CACHE` is instantiated from this and imported in `utils.py` and `run.py`.