### PR TITLE
Ensure no push if there are no changes

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -2,7 +2,7 @@
 set -ex
 
 git config user.email "casper+github@welzel.nu"
-git config user.name "CasperWA"
+git config user.name "Casper Welzel Andersen"
 
 echo "This is a test. ${RANDOM} ${RANDOM}" >> "ci_test_file.txt"
 mv -f extra_data_more.md ../

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
         sleep: 4
         unprotect_reviews: true
 
+    - name: Pushing to a protected branch without any changes
+      uses: ./
+      with:
+        token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
+        branch: protected
+        sleep: 4
+
   reset_test_branches_v1:
     needs: [not_protected, protected]
     runs-on: ubuntu-latest
@@ -164,3 +171,9 @@ jobs:
         branch: protected
         sleep: 4
         unprotect_reviews: true
+
+    - name: Pushing to a protected branch without any changes
+      uses: ./
+      with:
+        token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
+        branch: protected

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
       with:
         token: '${{ secrets.GITHUB_TOKEN }}'
         branch: not_protected
-        sleep: 4
         unprotect_reviews: false
 
   protected:
@@ -83,7 +82,6 @@ jobs:
       with:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
         branch: protected
-        sleep: 4
         unprotect_reviews: true
 
     - name: Pushing to a protected branch without any changes
@@ -91,7 +89,6 @@ jobs:
       with:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
         branch: protected
-        sleep: 4
 
   reset_test_branches_v1:
     needs: [not_protected, protected]
@@ -149,7 +146,6 @@ jobs:
       with:
         token: '${{ secrets.GITHUB_TOKEN }}'
         branch: not_protected
-        sleep: 4
         unprotect_reviews: false
 
   protected_v1:
@@ -169,7 +165,6 @@ jobs:
       with:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
         branch: protected
-        sleep: 4
         unprotect_reviews: true
 
     - name: Pushing to a protected branch without any changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     - name: Update version and tags
       run: .github/static/update_version.sh
 
+    # This will not work as intended, since 'push-action/**' has not been added to `ci.yml`.
+    # But it will be fine due to the powerful PAT.
     - name: Push updates to '${{ env.PUBLISH_UPDATE_BRANCH }}'
       uses: ./
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM python:3.8
+FROM python:alpine
 
 COPY README.md setup.py requirements*.txt ./
 COPY push_action ./push_action
-RUN pip install -U -e .
+
+RUN apk update \
+    && apk add --no-cache git bash \
+    && pip install -U -e .
 
 COPY entrypoint.sh ./
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ jobs:
       with:
         token: ${{ secrets.PUSH_TO_PROTECTED_BRANCH }}
         branch: main
-        sleep: 4
         unprotect_reviews: true
 
     - name: Build source distribution

--- a/push_action/run.py
+++ b/push_action/run.py
@@ -34,6 +34,7 @@ Configuration:
     )
 
     start_time = time()
+    unsuccessful_jobs = []
     while (time() - start_time) < (60 * IN_MEMORY_CACHE["args"].wait_timeout):
         for job in actions_required:
             if job["status"] != "completed":


### PR DESCRIPTION
Closes #27.

Add push to protected CI job immediately after the previous push to protected CI job, meaning there shouldn't be any changes/new commits and so there shouldn't be any pushes.
This, unfortunately, cannot be tested, but the outcome can be visually checked in the CI runs.