### PR TITLE
Update GH actions + pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     name: Reset test branches
     steps:
     - name: Checkout action repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         token: ${{ secrets.CI_RESET_TEST_BRANCHES }}
         fetch-depth: 0
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.2.2
       with:
         python-version: 3.9
 
@@ -52,7 +52,7 @@ jobs:
 
     steps:
     - name: Use local action (checkout)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
 
     - name: Perform changes
       run: ./ci.sh
@@ -71,7 +71,7 @@ jobs:
     name: Testing - protected
     steps:
     - name: Use local action (checkout)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
 
     - name: Perform changes
       run: ./ci.sh
@@ -96,13 +96,13 @@ jobs:
     name: Reset test branches - v1
     steps:
     - name: Checkout action repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         token: ${{ secrets.CI_RESET_TEST_BRANCHES }}
         fetch-depth: 0
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.2.2
       with:
         python-version: 3.9
 
@@ -135,7 +135,7 @@ jobs:
 
     steps:
     - name: Use local action (checkout)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.4
 
     - name: Perform changes
       run: ./ci.sh
@@ -154,7 +154,7 @@ jobs:
     name: Testing - protected - v1
     steps:
     - name: Use local action (checkout)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.4
 
     - name: Perform changes
       run: ./ci.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.2.2
       with:
         python-version: 3.8
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.5b1
     hooks:
     - id: black
       name: Blacken
@@ -17,6 +17,6 @@ repos:
     - id: end-of-file-fixer
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.4'
+    rev: '3.9.2'
     hooks:
     - id: flake8


### PR DESCRIPTION
Update GH actions according to @dependabot.

Update pre-commit hooks `black` and `flake8`.
No files were updated after updating and running `pre-commit run --all-files`.