### PR TITLE
Fixing issue that tags are removed before they can be pushed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ echo -e "\nGetting latest commit of ${GITHUB_REPOSITORY}@${INPUT_BRANCH} ..."
 git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :
 git submodule foreach --recursive 'git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :'
 git remote set-url origin https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/$GITHUB_REPOSITORY.git
-git fetch --unshallow -tpP origin || :
+git fetch --unshallow -tp origin || :
 echo "Getting latest commit of ${GITHUB_REPOSITORY}@${INPUT_BRANCH} ... DONE!"
 
 # Check whether there are newer commits on current branch compared to target branch


### PR DESCRIPTION
I ran into the issue that I created a new tag in my Github Action and when I want to push it (by specifying the tags: true) entry for your action, the line in entrypoint.sh that I edited in this PR fetches from origin and prunes all local tags that don't exist online as well. This kinda makes the whole option tags obsolete, as that seems to be overridden by this line.

If you find a nicer solution to actually be able to still push newly created tags, that's also fine, maybe by making this conditional on whether the `tags` flag was set or not, but this solution worked for me.