### PR TITLE
Action-specific variable names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/ambv/black
-    rev: 21.5b2
+    rev: 21.9b0
     hooks:
     - id: black
       name: Blacken

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Push Protected - GitHub Action
 
+<!-- markdownlint-disable MD033 -->
+
 _**Push to "status check"-protected branches.**_
 
 Push commit(s) to a branch protected by required [status checks](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) by creating a temporary branch, where status checks are run, before fast-forward merging it into the protected branch, finally removing the temporary branch.

--- a/action.yml
+++ b/action.yml
@@ -15,27 +15,27 @@ inputs:
   force:
     description: 'Determines if --force is used.'
     required: false
-    default: false
+    default: 'false'
   tags:
     description: 'Determines if --tags is used.'
     required: false
-    default: false
+    default: 'false'
   interval:
     description: 'Time interval (in seconds) between each new check, when waiting for status checks to complete'
     required: false
-    default: 30
+    default: '30'
   timeout:
     description: 'Time (in minutes) of how long the action should run before timing out, waiting for status checks to complete'
     required: false
-    default: 15
+    default: '15'
   sleep:
-    description: 'Time (in seconds) the action should wait until it will start "waiting" and check the list of running actions/checks. This should be an appropriate number to let the checks start up'
+    description: "Time (in seconds) the action should wait until it will start 'waiting' and check the list of running actions/checks. This should be an appropriate number to let the checks start up"
     required: false
-    default: 5
+    default: '5'
   unprotect_reviews:
     description: 'Momentarily remove pull request review protection from target branch'
     required: false
-    default: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
FIxes #50 

Prefixes all local bash variable names with `PUSH_PROTECTED_` to avoid clashing with workflow-created variables.

Minor updates:
- Explicitly use string values as default in `action.yml`.
- Update pre-commit hook `black` (no updates after running `pre-commit run --all-files`).
- Silence linting for using HTML in `README.md`.