### PR TITLE
Respect local state

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -2,16 +2,9 @@
 set -ex
 
 TAG_NAME=$1
-if [ -z "${TAG_NAME}" ]; then
-    if [ -z "${TEST_TAG}" ]; then
-        TAG_NAME=ci_test
-    else
-        TAG_NAME=${TEST_TAG}
-    fi
-fi
 
-git config user.email "casper+github@welzel.nu"
-git config user.name "Casper Welzel Andersen"
+git config --global user.email "casper+github@welzel.nu"
+git config --global user.name "Casper Welzel Andersen"
 
 echo "This is a test. ${RANDOM} ${RANDOM}" >> "ci_test_file.txt"
 mv -f extra_data_more.md ../
@@ -20,4 +13,6 @@ mv -f ci_test_file.txt ../../
 git add ../../ci_test_file.txt ../extra_data.log extra_data_more.md
 git commit -m "CI tests"
 
-git tag ci_test -a -m "This is a test tag"
+if [ -n "${TAG_NAME}" ]; then
+    git tag ${TAG_NAME} -a -m "This is a test tag"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     name: Reset test branches
     steps:
     - name: Checkout action repo
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
       with:
         token: ${{ secrets.CI_RESET_TEST_BRANCHES }}
         fetch-depth: 0
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: 3.9
 
@@ -56,7 +56,7 @@ jobs:
 
     steps:
     - name: Use local action (checkout)
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
 
     - name: Perform changes
       run: ./ci.sh ${TEST_TAG}
@@ -101,7 +101,7 @@ jobs:
     name: Testing - protected
     steps:
     - name: Use local action (checkout)
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
 
     - name: Perform changes
       run: ./ci.sh
@@ -126,13 +126,13 @@ jobs:
     name: Reset test branches - v1
     steps:
     - name: Checkout action repo
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
       with:
         token: ${{ secrets.CI_RESET_TEST_BRANCHES }}
         fetch-depth: 0
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: 3.9
 
@@ -166,7 +166,7 @@ jobs:
 
     steps:
     - name: Use local action (checkout)
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v1
 
     - name: Perform changes
       run: ./ci.sh ${TEST_TAG}
@@ -211,7 +211,7 @@ jobs:
     name: Testing - protected - v1
     steps:
     - name: Use local action (checkout)
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v1
 
     - name: Perform changes
       run: ./ci.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         git tag -l | grep "${TEST_TAG}"
 
   protected:
-    needs: reset_test_branches
+    needs: [reset_test_branches, not_protected]
     runs-on: ubuntu-latest
     name: Testing - protected
     steps:
@@ -206,7 +206,7 @@ jobs:
         git tag -l | grep "${TEST_TAG}"
 
   protected_v1:
-    needs: reset_test_branches_v1
+    needs: [reset_test_branches_v1, not_protected_v1]
     runs-on: ubuntu-latest
     name: Testing - protected - v1
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,52 @@ jobs:
       with:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
         branch: protected
+        unprotect_reviews: true
+
+  force-pushing:
+    needs: [protected]
+    runs-on: ubuntu-latest
+    name: Testing - protected (--force)
+    steps:
+    - name: Use local action (checkout)
+      uses: actions/checkout@v2
+
+    - name: Perform non-fast-forwardable changes
+      run: |
+        git config --global user.email "casper+github@welzel.nu"
+        git config --global user.name "Casper Welzel Andersen"
+
+        git fetch origin
+        git reset --hard ${{ github.sha }}
+        touch test.txt
+        git add test.txt
+        git commit -m "Diverged from remote branch"
+
+    - name: Push not using `--force` (should fail)
+      id: push_no_force
+      continue-on-error: true
+      uses: ./
+      with:
+        token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
+        branch: protected
+        unprotect_reviews: true
+
+    - name: This runs ONLY if the previous step doesn't fail
+      if: steps.push_no_force.outcome != 'failure' || steps.push_no_force.conclusion != 'success'
+      run: |
+        echo "Outcome: ${{ steps.push_no_force.outcome }} (not 'failure'), Conclusion: ${{ steps.push_no_force.conclusion }} (not 'success')"
+        exit 1
+
+    - name: Push using `--force` (should succeed)
+      uses: ./
+      with:
+        token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
+        branch: protected
+        unprotect_reviews: true
+        force: yes
 
   reset_test_branches_v1:
-    needs: [not_protected, protected]
+    needs: [not_protected, protected, force-pushing]
     runs-on: ubuntu-latest
     name: Reset test branches - v1
     steps:
@@ -229,3 +272,45 @@ jobs:
       with:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
         branch: protected
+
+  force-pushing_v1:
+    needs: [protected_v1]
+    runs-on: ubuntu-latest
+    name: Testing - protected (--force) - v1
+    steps:
+    - name: Use local action (checkout)
+      uses: actions/checkout@v1
+
+    - name: Perform non-fast-forwardable changes
+      run: |
+        git config --global user.email "casper+github@welzel.nu"
+        git config --global user.name "Casper Welzel Andersen"
+
+        git fetch origin
+        git reset --hard ${{ github.sha }}
+        touch test.txt
+        git add test.txt
+        git commit -m "Diverged from remote branch"
+
+    - name: Push not using `--force` (should fail)
+      id: push_no_force
+      continue-on-error: true
+      uses: ./
+      with:
+        token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
+        branch: protected
+        unprotect_reviews: true
+
+    - name: This runs ONLY if the previous step doesn't fail
+      if: steps.push_no_force.outcome != 'failure' || steps.push_no_force.conclusion != 'success'
+      run: |
+        echo "Outcome: ${{ steps.push_no_force.outcome }} (not 'failure'), Conclusion: ${{ steps.push_no_force.conclusion }} (not 'success')"
+        exit 1
+
+    - name: Push using `--force` (should succeed)
+      uses: ./
+      with:
+        token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
+        branch: protected
+        unprotect_reviews: true
+        force: yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,7 @@ push_tags() {
 echo -e "\nGetting latest commit of ${GITHUB_REPOSITORY}@${INPUT_BRANCH} ..."
 git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :
 git submodule foreach --recursive 'git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :'
-git remote set-url origin https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/$GITHUB_REPOSITORY.git
+git remote set-url origin https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 git fetch --unshallow -tp origin || :
 echo "Getting latest commit of ${GITHUB_REPOSITORY}@${INPUT_BRANCH} ... DONE!"
 
@@ -78,7 +78,7 @@ PUSH_PROTECTED_PROTECTED_BRANCH=$(push-action --token "${INPUT_TOKEN}" --ref "${
 # Create new temporary repository
 PUSH_PROTECTED_TEMPORARY_BRANCH="push-action/${GITHUB_RUN_ID}/${RANDOM}-${RANDOM}-${RANDOM}"
 echo -e "\nCreating temporary repository '${PUSH_PROTECTED_TEMPORARY_BRANCH}' ..."
-git checkout -f -b ${PUSH_PROTECTED_TEMPORARY_BRANCH}
+git checkout -f -b ${PUSH_PROTECTED_TEMPORARY_BRANCH}  # throws away any local un-committed changes
 if [ -n "${PUSH_PROTECTED_CHANGED_BRANCH}" ] && [ -n "${PUSH_PROTECTED_PROTECTED_BRANCH}" ]; then
     git push -f origin ${PUSH_PROTECTED_TEMPORARY_BRANCH}
 fi
@@ -118,13 +118,14 @@ esac
     unprotect &&
 
     # Merge into target branch
-    echo -e "\nMerging (fast-forward) '${PUSH_PROTECTED_TEMPORARY_BRANCH}' -> '${INPUT_BRANCH}' ..." &&
+    echo -e "\nPushing '${PUSH_PROTECTED_TEMPORARY_BRANCH}' -> 'origin/${INPUT_BRANCH}' ..." &&
     git checkout ${INPUT_BRANCH} &&
-    git reset --hard origin/${INPUT_BRANCH} &&
-    git merge --ff-only ${PUSH_PROTECTED_TEMPORARY_BRANCH} &&
+    git reset --hard ${PUSH_PROTECTED_TEMPORARY_BRANCH} &&
+    # git reset --hard origin/${INPUT_BRANCH} &&
+    # git merge --ff-only ${PUSH_PROTECTED_TEMPORARY_BRANCH} &&
     git push ${PUSH_PROTECTED_FORCE_PUSH} &&
     push_tags &&
-    echo "Merging (fast-forward) '${PUSH_PROTECTED_TEMPORARY_BRANCH}' -> '${INPUT_BRANCH}' ... DONE!" &&
+    echo "Pushing '${PUSH_PROTECTED_TEMPORARY_BRANCH}' -> 'origin/${INPUT_BRANCH}' ... DONE!" &&
 
     # Re-protect target branch for pull request reviews (if desired)
     protect &&


### PR DESCRIPTION
Fixes #52 

Remove the fast-forward merging steps and simply reset the local state to be equal to the temporary branch and push.

Also implements:
- Don't run CI jobs in parallel.
- Actually use `checkout@v1` for "v1" CI jobs.
- Use vMAJOR for all GitHub Actions.