### PR TITLE
Exclude `ci_test` and vMAJOR tags for changelog gen

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        exclude_tags_regex: "^(ci_test|v[0-9]+)$"
 
     - name: Update version and tags
       run: .github/utils/update_version.sh
@@ -62,6 +63,7 @@ jobs:
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
+        exclude_tags_regex: "^(ci_test|v[0-9]+)$"
 
     - name: Append changelog to release body
       run: |


### PR DESCRIPTION
Fixes #77 