### PR TITLE
Add `ref` argument

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -79,7 +79,7 @@ jobs:
       uses: ./
       with:
         token: '${{ secrets.GITHUB_TOKEN }}'
-        branch: not_protected
+        ref: refs/heads/not_protected
         unprotect_reviews: false
         tags: true
 
@@ -112,7 +112,7 @@ jobs:
       uses: ./
       with:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
-        branch: protected
+        ref: refs/heads/protected
         unprotect_reviews: true
 
   force-pushing:
@@ -157,8 +157,32 @@ jobs:
         unprotect_reviews: true
         force: yes
 
+  branch_and_ref:
+    needs: [force-pushing]
+    runs-on: ubuntu-latest
+    name: Test setting `branch` and `ref` fails
+    steps:
+    - name: Use local action (checkout)
+      uses: actions/checkout@v2
+
+    - name: Push setting both `branch` and `ref` (should fail)
+      id: push_branch_ref
+      continue-on-error: true
+      uses: ./
+      with:
+        token: '${{ secrets.GITHUB_TOKEN }}'
+        branch: not_protected
+        ref: refs/heads/not_protected
+        unprotect_reviews: false
+
+    - name: This runs ONLY if the previous step doesn't fail
+      if: steps.push_branch_ref.outcome != 'failure' || steps.push_branch_ref.conclusion != 'success'
+      run: |
+        echo "Outcome: ${{ steps.push_branch_ref.outcome }} (not 'failure'), Conclusion: ${{ steps.push_branch_ref.conclusion }} (not 'success')"
+        exit 1
+
   reset_test_branches_v1:
-    needs: [not_protected, protected, force-pushing]
+    needs: [not_protected, protected, force-pushing, branch_and_ref]
     runs-on: ubuntu-latest
     name: Reset test branches - v1
     steps:
@@ -228,7 +252,7 @@ jobs:
       uses: ./
       with:
         token: '${{ secrets.GITHUB_TOKEN }}'
-        branch: not_protected
+        ref: refs/heads/not_protected
         unprotect_reviews: false
         tags: true
 
@@ -261,7 +285,8 @@ jobs:
       uses: ./
       with:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
-        branch: protected
+        ref: refs/heads/protected
+        unprotect_review: true
 
   force-pushing_v1:
     needs: [protected_v1]
@@ -304,6 +329,30 @@ jobs:
         branch: protected
         unprotect_reviews: true
         force: yes
+
+  branch_and_ref_v1:
+    needs: [force-pushing_v1]
+    runs-on: ubuntu-latest
+    name: Test setting `branch` and `ref` fails - v1
+    steps:
+    - name: Use local action (checkout)
+      uses: actions/checkout@v1
+
+    - name: Push setting both `branch` and `ref` (should fail)
+      id: push_branch_ref
+      continue-on-error: true
+      uses: ./
+      with:
+        token: '${{ secrets.GITHUB_TOKEN }}'
+        branch: not_protected
+        ref: refs/heads/not_protected
+        unprotect_reviews: false
+
+    - name: This runs ONLY if the previous step doesn't fail
+      if: steps.push_branch_ref.outcome != 'failure' || steps.push_branch_ref.conclusion != 'success'
+      run: |
+        echo "Outcome: ${{ steps.push_branch_ref.outcome }} (not 'failure'), Conclusion: ${{ steps.push_branch_ref.conclusion }} (not 'success')"
+        exit 1
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ All input names in **bold** are _required_.
 | Name | Description | Default |
 |:---:|:---|:---:|
 | **`token`** | Token for the repo.<br>Used for authentication and starting 'push' hooks. See above for notes on this input. | |
-| `branch` | Target branch for the push. | `master` |
+| `branch` | Target branch for the push. Mutually exclusive with "ref".<br>Example: `"main"`. | `master` |
+| `ref` | Target ref for the push. Mutually exclusive with "branch".<br>Example: `"refs/heads/main"`. | |
 | `force` | Determines if `--force` is used. | `False` |
 | `tags` | Determines if `--tags` is used. | `False` |
 | `interval` | Time interval (in seconds) between each new check, when waiting for status checks to complete. | `30` |

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,13 @@ inputs:
     description: 'Token for the repo.'
     required: true
   branch:
-    description: 'Target branch for the push.'
+    description: 'Target branch for the push. Mutually exclusive with "ref". Example: "main".'
     required: false
-    default: 'master'
+    default: ''
+  ref:
+    description: 'Target ref for the push. Mutually exclusive with "branch". Example: "refs/heads/main".'
+    required: false
+    default: ''
   force:
     description: 'Determines if --force is used.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,21 @@ push_to_target() {
     git push ${PUSH_PROTECTED_FORCE_PUSH}
 }
 
+# Determine branch
+if [ -n "${INPUT_REF}" ]; then
+    if [ -n "${INPUT_BRANCH}" ]; then
+        echo -e "\nInputs 'branch' and 'ref' are mutually exclusive; please only define one."
+        exit 1
+    else
+        # Only `ref` is defined - use it to define `INPUT_BRANCH`, which is used throughout the workflow.
+        INPUT_BRANCH=${INPUT_REF#refs/heads/}
+        unset INPUT_REF
+    fi
+elif [ -z "${INPUT_BRANCH}" ]; then
+    # Neither `ref` or `branch` are defined - use default: `branch: "master"`.
+    INPUT_BRANCH=master
+fi
+
 # Retrieve target repository
 echo -e "\nGetting latest commit of ${GITHUB_REPOSITORY}@${INPUT_BRANCH} ..."
 git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :

--- a/push_action/run.py
+++ b/push_action/run.py
@@ -204,7 +204,7 @@ def main() -> None:
     parser.add_argument(
         "--ref",
         type=str,
-        help="Target ref (branch/tag) for the push",
+        help="Target ref branch for the push",
         required=True,
     )
     parser.add_argument(


### PR DESCRIPTION
Closes #61 

The new `ref` is mutually exclusive with the `branch` argument, meaning exactly one can be defined.
Furthermore, if none are defined, the old behavior persists, i.e., `branch: "master"`.