### PR TITLE
Use `main` as default `branch` value instead of `master`

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -160,7 +160,7 @@ jobs:
   branch_and_ref:
     needs: [force-pushing]
     runs-on: ubuntu-latest
-    name: Test setting `branch` and `ref` fails
+    name: Testing - Setting `branch` and `ref` fails
     steps:
     - name: Use local action (checkout)
       uses: actions/checkout@v2
@@ -181,8 +181,31 @@ jobs:
         echo "Outcome: ${{ steps.push_branch_ref.outcome }} (not 'failure'), Conclusion: ${{ steps.push_branch_ref.conclusion }} (not 'success')"
         exit 1
 
+  non_existant_branch:
+    needs: [branch_and_ref]
+    runs-on: ubuntu-latest
+    name: Testing - Fail for non-existant branch
+    steps:
+    - name: Use local action (checkout)
+      uses: actions/checkout@v2
+
+    - name: Push to non-existant branch (should fail)
+      id: push_non_existant
+      continue-on-error: true
+      uses: ./
+      with:
+        token: '${{ secrets.GITHUB_TOKEN }}'
+        branch: non-existant-branch
+        unprotect_reviews: false
+
+    - name: This runs ONLY if the previous step doesn't fail
+      if: steps.push_non_existant.outcome != 'failure' || steps.push_non_existant.conclusion != 'success'
+      run: |
+        echo "Outcome: ${{ steps.push_non_existant.outcome }} (not 'failure'), Conclusion: ${{ steps.push_non_existant.conclusion }} (not 'success')"
+        exit 1
+
   reset_test_branches_v1:
-    needs: [not_protected, protected, force-pushing, branch_and_ref]
+    needs: [not_protected, protected, force-pushing, branch_and_ref, non_existant_branch]
     runs-on: ubuntu-latest
     name: Reset test branches - v1
     steps:
@@ -333,7 +356,7 @@ jobs:
   branch_and_ref_v1:
     needs: [force-pushing_v1]
     runs-on: ubuntu-latest
-    name: Test setting `branch` and `ref` fails - v1
+    name: Testing - Setting `branch` and `ref` fails - v1
     steps:
     - name: Use local action (checkout)
       uses: actions/checkout@v1
@@ -352,6 +375,29 @@ jobs:
       if: steps.push_branch_ref.outcome != 'failure' || steps.push_branch_ref.conclusion != 'success'
       run: |
         echo "Outcome: ${{ steps.push_branch_ref.outcome }} (not 'failure'), Conclusion: ${{ steps.push_branch_ref.conclusion }} (not 'success')"
+        exit 1
+
+  non_existant_branch_v1:
+    needs: [branch_and_ref_v1]
+    runs-on: ubuntu-latest
+    name: Testing - Fail for non-existant branch - v1
+    steps:
+    - name: Use local action (checkout)
+      uses: actions/checkout@v1
+
+    - name: Push to non-existant branch (should fail)
+      id: push_non_existant
+      continue-on-error: true
+      uses: ./
+      with:
+        token: '${{ secrets.GITHUB_TOKEN }}'
+        branch: non-existant-branch
+        unprotect_reviews: false
+
+    - name: This runs ONLY if the previous step doesn't fail
+      if: steps.push_non_existant.outcome != 'failure' || steps.push_non_existant.conclusion != 'success'
+      run: |
+        echo "Outcome: ${{ steps.push_non_existant.outcome }} (not 'failure'), Conclusion: ${{ steps.push_non_existant.conclusion }} (not 'success')"
         exit 1
 
   pre-commit:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ All input names in **bold** are _required_.
 | Name | Description | Default |
 |:---:|:---|:---:|
 | **`token`** | Token for the repo.<br>Used for authentication and starting 'push' hooks. See above for notes on this input. | |
-| `branch` | Target branch for the push. Mutually exclusive with "ref".<br>Example: `"main"`. | `master` |
+| `branch` | Target branch for the push. Mutually exclusive with "ref".<br>Example: `"main"`. | `main` |
 | `ref` | Target ref for the push. Mutually exclusive with "branch".<br>Example: `"refs/heads/main"`. | |
 | `force` | Determines if `--force` is used. | `False` |
 | `tags` | Determines if `--tags` is used. | `False` |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,15 +79,15 @@ elif [ -z "${INPUT_BRANCH}" ]; then
 fi
 
 # Retrieve target repository
-echo -e "\nFetching the latest information from ${GITHUB_REPOSITORY} ..."
+echo -e "\nFetching the latest information from '${GITHUB_REPOSITORY}' ..."
 git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :
 git submodule foreach --recursive 'git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :'
 git remote set-url origin https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 git fetch --unshallow -tp origin || :
-echo "Fetching the latest information from ${GITHUB_REPOSITORY} ... DONE!"
+echo "Fetching the latest information from '${GITHUB_REPOSITORY}' ... DONE!"
 
 # Check target branch exists
-echo -e "\nCheck target branch ${INPUT_BRANCH} exists ..."
+echo -e "\nCheck target branch '${INPUT_BRANCH}' exists ..."
 if [ -z "$(git branch -a | grep -E ^.*remotes/origin/${INPUT_BRANCH}$ )" ]; then
     # Branch does not exist on remote
     # If branch was set to the default (`main`) try the current standard `git` default branch name: `master`
@@ -96,11 +96,11 @@ if [ -z "$(git branch -a | grep -E ^.*remotes/origin/${INPUT_BRANCH}$ )" ]; then
         INPUT_BRANCH=master
         echo "Changed target branch from 'main' to '${INPUT_BRANCH}'."
     else
-        echo "ERROR: Branch '${INPUT_BRANCH}' cannot be found in the ${GITHUB_REPOSITORY} repository !"
+        echo -e "Branch '${INPUT_BRANCH}' cannot be found in the '${GITHUB_REPOSITORY}' repository !\nExiting."
         exit 1
     fi
 fi
-echo "Check target branch ${INPUT_BRANCH} exists ... DONE!"
+echo "Check target branch '${INPUT_BRANCH}' exists ... DONE!"
 
 # Check whether there are newer commits on current branch compared to target branch
 if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/${INPUT_BRANCH})" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,10 +88,10 @@ echo "Fetching the latest information from ${GITHUB_REPOSITORY} ... DONE!"
 
 # Check target branch exists
 echo -e "\nCheck target branch ${INPUT_BRANCH} exists ..."
-if [ -z "$(git branch -a | grep -E ^.*remotes/origin/${INPUT_BRANCH}$ )"]; then
+if [ -z "$(git branch -a | grep -E ^.*remotes/origin/${INPUT_BRANCH}$ )" ]; then
     # Branch does not exist on remote
     # If branch was set to the default (`main`) try the current standard `git` default branch name: `master`
-    if [ "${INPUT_BRANCH}" = "main" ] && [ -n "$(git branch -a | grep -E ^.*remotes/origin/master$ )"]; then
+    if [ "${INPUT_BRANCH}" = "main" ] && [ -n "$(git branch -a | grep -E ^.*remotes/origin/master$ )" ]; then
         # `master` exists - use it as the fallback default instead of the non-existing `main`
         INPUT_BRANCH=master
         echo "Changed target branch from 'main' to '${INPUT_BRANCH}'."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,8 +74,8 @@ if [ -n "${INPUT_REF}" ]; then
         unset INPUT_REF
     fi
 elif [ -z "${INPUT_BRANCH}" ]; then
-    # Neither `ref` or `branch` are defined - use default: `branch: "master"`.
-    INPUT_BRANCH=master
+    # Neither `ref` or `branch` are defined - use default: `branch: "main"`.
+    INPUT_BRANCH=main
 fi
 
 # Retrieve target repository

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,12 +79,28 @@ elif [ -z "${INPUT_BRANCH}" ]; then
 fi
 
 # Retrieve target repository
-echo -e "\nGetting latest commit of ${GITHUB_REPOSITORY}@${INPUT_BRANCH} ..."
+echo -e "\nFetching the latest information from ${GITHUB_REPOSITORY} ..."
 git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :
 git submodule foreach --recursive 'git config --local --name-only --get-regexp "http\.https\:\/\/github\.com\/\.extraheader" && git config --local --unset-all "http.https://github.com/.extraheader" || :'
 git remote set-url origin https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 git fetch --unshallow -tp origin || :
-echo "Getting latest commit of ${GITHUB_REPOSITORY}@${INPUT_BRANCH} ... DONE!"
+echo "Fetching the latest information from ${GITHUB_REPOSITORY} ... DONE!"
+
+# Check target branch exists
+echo -e "\nCheck target branch ${INPUT_BRANCH} exists ..."
+if [ -z "$(git branch -a | grep -E ^.*remotes/origin/${INPUT_BRANCH}$ )"]; then
+    # Branch does not exist on remote
+    # If branch was set to the default (`main`) try the current standard `git` default branch name: `master`
+    if [ "${INPUT_BRANCH}" = "main" ] && [ -n "$(git branch -a | grep -E ^.*remotes/origin/master$ )"]; then
+        # `master` exists - use it as the fallback default instead of the non-existing `main`
+        INPUT_BRANCH=master
+        echo "Changed target branch from 'main' to '${INPUT_BRANCH}'."
+    else
+        echo "ERROR: Branch '${INPUT_BRANCH}' cannot be found in the ${GITHUB_REPOSITORY} repository !"
+        exit 1
+    fi
+fi
+echo "Check target branch ${INPUT_BRANCH} exists ... DONE!"
 
 # Check whether there are newer commits on current branch compared to target branch
 if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/${INPUT_BRANCH})" ]; then


### PR DESCRIPTION
Close #80 

Don't merge just yet, as this is slightly backwards incompatible - in the sense that one has to manually set the `branch` value in cases where the default is being used (or update the target branch name accordingly).