### PR TITLE
Finish update to `main` with `master` tag

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-        exclude_tags_regex: "^(ci_test|v[0-9]+)$"
+        exclude_tags_regex: "^(ci_test|master|v[0-9]+)$"
 
     - name: Update version and tags
       run: .github/utils/update_version.sh
@@ -63,7 +63,7 @@ jobs:
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
-        exclude_tags_regex: "^(ci_test|v[0-9]+)$"
+        exclude_tags_regex: "^(ci_test|master|v[0-9]+)$"
 
     - name: Append changelog to release body
       run: |

--- a/.github/workflows/ci_updated_main.yml
+++ b/.github/workflows/ci_updated_main.yml
@@ -4,17 +4,17 @@ on:
   push:
     branches: [main]
 
+env:
+  DEPENDABOT_BRANCH: ci/dependabot-updates
+  GIT_USER_NAME: CasperWA
+  GIT_USER_EMAIL: "casper+github@welzel.nu"
+  DEFAULT_REPO_BRANCH: main
+
 jobs:
   update-dependabot-branch:
     name: Update permanent dependabot branch
     if: github.repository_owner == 'CasperWA'
     runs-on: ubuntu-latest
-
-    env:
-      DEPENDABOT_BRANCH: ci/dependabot-updates
-      GIT_USER_NAME: CasperWA
-      GIT_USER_EMAIL: "casper+github@welzel.nu"
-      DEFAULT_REPO_BRANCH: main
 
     steps:
     - name: Checkout repository
@@ -50,3 +50,32 @@ jobs:
         git push -f
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-master-tag:
+    name: Update the `master` tag
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.DEPENDABOT_BRANCH }}
+        fetch-depth: 0
+
+    - name: Set up git config
+      run: |
+        git config --global user.name "${{ env.GIT_USER_NAME }}"
+        git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+
+    - name: Update tag
+      run: |
+        git tag -l master --format "%(contents:subject)%0a%0a%(contents:body)" > MASTER_TAG_MSG.txt
+        git tag -af -F "MASTER_TAG_MSG.txt" master
+        rm -f MASTER_TAG_MSG.txt
+
+    - name: Push updated tag
+      uses: ./
+      with:
+        token: ${{ secrets.CI_RESET_TEST_BRANCHES }}
+        branch: ${{ env.DEFAULT_REPO_BRANCH }}
+        tags: true


### PR DESCRIPTION
Closes #84 

Don't include the `master` tag in the CHANGELOG generation.

Keep the `master` tag up-to-date with the `main` branch's HEAD commit.