### PR TITLE
Fix CI runs for `main` updates

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -1,10 +1,6 @@
 name: CI Tests
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
+on: [pull_request]
 
 env:
   TEST_TAG: ci_test

--- a/.github/workflows/ci_updated_main.yml
+++ b/.github/workflows/ci_updated_main.yml
@@ -39,12 +39,10 @@ jobs:
           # The dependency branch should be reset to `${{ env.DEFAULT_REPO_BRANCH }}`
           echo "The dependencies have just been updated! Reset to ${{ env.DEFAULT_REPO_BRANCH }}."
           git reset --hard origin/${{ env.DEFAULT_REPO_BRANCH }}
-          echo "FORCE_PUSH=yes" >> $GITHUB_ENV
         else
           # Normal procedure: Merge `${{ env.DEFAULT_REPO_BRANCH }}` into `${{ env.DEPENDABOT_BRANCH }}`
           echo "Merge new updates to ${{ env.DEFAULT_REPO_BRANCH }} into ${DEPENDABOT_BRANCH}"
           git merge -m "Keep '${{ env.DEPENDABOT_BRANCH }}' up-to-date with '${{ env.DEFAULT_REPO_BRANCH }}'" origin/${{ env.DEFAULT_REPO_BRANCH }}
-          echo "FORCE_PUSH=no" >> $GITHUB_ENV
         fi
 
         git push -f
@@ -59,7 +57,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
-        ref: ${{ env.DEPENDABOT_BRANCH }}
         fetch-depth: 0
 
     - name: Set up git config


### PR DESCRIPTION
Fixes #86 

Checkout `main` instead of `ci/dependabot-updates` for updating the `master` tag.

Don't run CI on pushes to `main` - only for pull requests.