### PR TITLE
Sleep 5 seconds after status checks are done

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,7 +171,6 @@ esac
 {
     # Possibly wait for status checks to complete
     wait_for_checks &&
-    
     # Sleep 5 seconds to add addtional time buffer for status checks
     sleep 5 &&
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,6 +171,9 @@ esac
 {
     # Possibly wait for status checks to complete
     wait_for_checks &&
+    
+    # Sleep 5 seconds to add addtional time buffer for status checks
+    sleep 5 &&
 
     # Unprotect target branch for pull request reviews (if desired)
     unprotect &&


### PR DESCRIPTION
We ran into a random issue that even if the desired checks are successfully done, the action reports one of them is still in progress.

<img width="802" alt="image" src="https://user-images.githubusercontent.com/14722250/178036736-893c902c-a569-464d-8b19-2fba7095796c.png">

Usually a re-run would solve it, so I'd like to give GitHub Actions 5 more seconds to ensure status has been synced.