### PR TITLE
Expect the `protected` key to always exist

### DIFF
--- a/push_action/run.py
+++ b/push_action/run.py
@@ -33,7 +33,6 @@ from typing import TYPE_CHECKING
 from push_action.cache import IN_MEMORY_CACHE
 from push_action.utils import (
     api_request,
-    check_user_role,
     get_branch_statuses,
     get_required_actions,
     get_required_checks,
@@ -188,17 +187,14 @@ def protected_branch(branch: str) -> str:
     """
     url = f"/repos/{os.getenv('GITHUB_REPOSITORY', '')}/branches/{branch}"
     response: "Dict[str, Any]" = api_request(url)  # type: ignore[assignment]
-    if response.get("protected", False):
-        if check_user_role("admin"):
-            return "protected"
 
+    if "protected" not in response:
         raise RuntimeError(
-            "Not enough rights to continue pushing to a protected branch - should "
-            "have 'admin' permissions (Admin role)."
+            f"Information regarding whether the branch {branch} is protected cannot be "
+            "retrieved."
         )
 
-    # Not protected, return an empty string
-    return ""
+    return "protected" if response["protected"] else ""
 
 
 def main() -> None:

--- a/push_action/utils.py
+++ b/push_action/utils.py
@@ -71,7 +71,7 @@ def api_request(
         response = requests_action(
             url,
             headers={
-                "Authorization": f"token {IN_MEMORY_CACHE['args'].token}",
+                "Authorization": f"Bearer {IN_MEMORY_CACHE['args'].token}",
                 "Accept": "application/vnd.github.v3+json",
             },
             timeout=REQUEST_TIMEOUT,
@@ -270,25 +270,3 @@ def get_required_checks(
     TODO: Currently not implemented
     """
     return []
-
-
-def check_user_role(
-    role: "Optional[Union[RepoRole, str]]" = None, new_request: bool = False
-) -> bool:
-    """Check the user's role."""
-    role = RepoRole.ADMIN if role is None else RepoRole(role)
-
-    cache_name = f"check_user_role_{role.value}"
-
-    if cache_name not in IN_MEMORY_CACHE or new_request:
-        url = f"/repos/{os.getenv('GITHUB_REPOSITORY', '')}"
-        response = api_request(url=url)
-
-        if not isinstance(response, dict):
-            raise TypeError(
-                f"Expected response to be a dict, instead it was of type {type(response)}"
-            )
-
-        IN_MEMORY_CACHE[cache_name] = response["permissions"].get(role.value, False)
-
-    return IN_MEMORY_CACHE[cache_name]


### PR DESCRIPTION
Closes #144 

This is to avoid having to determine the user's role to infer whether a branch is protected or not.