### PR TITLE
Add custom acceptable job run conclusions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -103,6 +103,7 @@ jobs:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
         branch: protected
         unprotect_reviews: true
+        acceptable_conclusions: success,skipped
 
     - name: Pushing to a protected branch without any changes
       uses: ./
@@ -110,6 +111,7 @@ jobs:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
         ref: refs/heads/protected
         unprotect_reviews: true
+        acceptable_conclusions: success,skipped
 
   force-pushing:
     needs: [protected]
@@ -138,6 +140,7 @@ jobs:
         token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
         branch: protected
         unprotect_reviews: true
+        acceptable_conclusions: success,skipped
 
     - name: This runs ONLY if the previous step doesn't fail
       if: steps.push_no_force.outcome != 'failure' || steps.push_no_force.conclusion != 'success'
@@ -152,6 +155,7 @@ jobs:
         branch: protected
         unprotect_reviews: true
         force: yes
+        acceptable_conclusions: success,skipped
 
   branch_and_ref:
     needs: [force-pushing]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -104,7 +104,6 @@ jobs:
         branch: protected
         unprotect_reviews: true
         acceptable_conclusions: success,skipped
-        debug: true
 
     - name: Pushing to a protected branch without any changes
       uses: ./
@@ -113,7 +112,6 @@ jobs:
         ref: refs/heads/protected
         unprotect_reviews: true
         acceptable_conclusions: success,skipped
-        debug: true
 
   force-pushing:
     needs: [protected]
@@ -233,6 +231,10 @@ jobs:
     steps:
       - name: Use local action (checkout)
         uses: actions/checkout@v4
+
+      - name: Perform changes
+        run: ./ci.sh
+        working-directory: .github/utils
 
       - name: Push to protected branch without 'skipped' in 'acceptable_conclusions'
         id: push_skipped

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -246,6 +246,7 @@ jobs:
           unprotect_reviews: true
           # Default value - set here explicitly for clarity
           acceptable_conclusions: success
+          debug: true
 
       - name: This runs ONLY if the previous step doesn't fail
         if: steps.push_skipped.outcome != 'failure' || steps.push_skipped.conclusion != 'success'

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -64,7 +64,6 @@ jobs:
         token: '${{ secrets.GITHUB_TOKEN }}'
         branch: not_protected
         unprotect_reviews: false
-        debug: true
 
     - name: Check tags (local)
       run: |
@@ -247,7 +246,6 @@ jobs:
           unprotect_reviews: true
           # Default value - set here explicitly for clarity
           acceptable_conclusions: success
-          debug: true
 
       - name: This runs ONLY if the previous step doesn't fail
         if: steps.push_skipped.outcome != 'failure' || steps.push_skipped.conclusion != 'success'

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -104,6 +104,7 @@ jobs:
         branch: protected
         unprotect_reviews: true
         acceptable_conclusions: success,skipped
+        debug: true
 
     - name: Pushing to a protected branch without any changes
       uses: ./
@@ -112,6 +113,7 @@ jobs:
         ref: refs/heads/protected
         unprotect_reviews: true
         acceptable_conclusions: success,skipped
+        debug: true
 
   force-pushing:
     needs: [protected]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -224,6 +224,31 @@ jobs:
         force: yes
         debug: true
 
+  acceptable_conclusions:
+    needs: [path]
+    runs-on: ubuntu-latest
+    name: Testing - Default for `acceptable_conclusions` with skipped checks
+    steps:
+      - name: Use local action (checkout)
+        uses: actions/checkout@v4
+
+      - name: Push to protected branch without 'skipped' in 'acceptable_conclusions'
+        id: push_skipped
+        continue-on-error: true
+        uses: ./
+        with:
+          token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
+          branch: protected
+          unprotect_reviews: true
+          # Default value - set here explicitly for clarity
+          acceptable_conclusions: success
+
+      - name: This runs ONLY if the previous step doesn't fail
+        if: steps.push_skipped.outcome != 'failure' || steps.push_skipped.conclusion != 'success'
+        run: |
+          echo "Outcome: ${{ steps.push_skipped.outcome }} (not 'failure'), Conclusion: ${{ steps.push_skipped.conclusion }} (not 'success')"
+          exit 1
+
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -64,6 +64,7 @@ jobs:
         token: '${{ secrets.GITHUB_TOKEN }}'
         branch: not_protected
         unprotect_reviews: false
+        debug: true
 
     - name: Check tags (local)
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -222,7 +222,7 @@ jobs:
         unprotect_reviews: true
         path: sub_folder
         force: yes
-        debug: true
+        acceptable_conclusions: success,skipped
 
   acceptable_conclusions:
     needs: [path]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -253,6 +253,36 @@ jobs:
           echo "Outcome: ${{ steps.push_skipped.outcome }} (not 'failure'), Conclusion: ${{ steps.push_skipped.conclusion }} (not 'success')"
           exit 1
 
+  fail_fast:
+    needs: [acceptable_conclusions]
+    runs-on: ubuntu-latest
+    name: Testing - Using `fail_fast`
+    steps:
+      - name: Use local action (checkout)
+        uses: actions/checkout@v4
+
+      - name: Perform changes
+        run: ./ci.sh
+        working-directory: .github/utils
+
+      - name: Push to protected branch without 'skipped' in 'acceptable_conclusions' & with 'fail_fast'
+        id: fail_fast
+        continue-on-error: true
+        uses: ./
+        with:
+          token: '${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}'
+          branch: protected
+          unprotect_reviews: true
+          # Default value - set here explicitly for clarity
+          acceptable_conclusions: success
+          fail_fast: true
+
+      - name: This runs ONLY if the previous step doesn't fail
+        if: steps.fail_fast.outcome != 'failure' || steps.fail_fast.conclusion != 'success'
+        run: |
+          echo "Outcome: ${{ steps.fail_fast.outcome }} (not 'failure'), Conclusion: ${{ steps.fail_fast.conclusion }} (not 'success')"
+          exit 1
+
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_status_checks.yml
+++ b/.github/workflows/test_status_checks.yml
@@ -29,4 +29,12 @@ jobs:
     if: ${{ !always() }}
     steps:
     - name: Skipped status check
-      run: echo "Very important skipped status check - SKIPPED!"
+      run: echo "Very important skipped status check - here for --acceptable-conclusion testing - SKIPPED!"
+
+  another_skipped_mock_status_check:
+    runs-on: ubuntu-latest
+    name: Another Skipped Mock Status Check
+    if: ${{ !always() }}
+    steps:
+    - name: Skipped status check
+      run: echo "Very important skipped status check - here for --fail-fast testing - SKIPPED!"

--- a/.github/workflows/test_status_checks.yml
+++ b/.github/workflows/test_status_checks.yml
@@ -22,3 +22,11 @@ jobs:
     steps:
     - name: Important status check
       run: echo "Very important status check - SUCCESS!"
+
+  skipped_mock_status_check:
+    runs-on: ubuntu-latest
+    name: Skipped Mock Status Check
+    if: ! always()
+    steps:
+    - name: Skipped status check
+      run: echo "Very important skipped status check - SKIPPED!"

--- a/.github/workflows/test_status_checks.yml
+++ b/.github/workflows/test_status_checks.yml
@@ -26,7 +26,7 @@ jobs:
   skipped_mock_status_check:
     runs-on: ubuntu-latest
     name: Skipped Mock Status Check
-    if: ! always()
+    if: ${{ !always() }}
     steps:
     - name: Skipped status check
       run: echo "Very important skipped status check - SKIPPED!"

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ All input names in **bold** are _required_.
 | `unprotect_reviews` | Momentarily remove pull request review protection from target branch.<br>**Note**: One needs administrative access to the repository to be able to use this feature. This means two things need to match up: The PAT must represent a user with administrative rights, and these rights need to be granted to the usage scope of the PAT. | `False` |
 | `debug` | Set `set -x` in `entrypoint.sh` when running the action. This is for debugging the action. | `False` |
 | `path` | A path to the working directory of the action. This should be relative to the `$GITHUB_WORKSPACE`. | `.` |
+| `acceptable_conclusions` | A comma-separated list of acceptable statuses. If any of these statuses are present, the action will not fail.</br></br>See the [GitHub REST API documentation](https://docs.github.com/en/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run), specifically, the Response schema's "conclusion" property's `enum` values, for a complete list of supported values (excluding `null`). | `success` |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ All input names in **bold** are _required_.
 | `path` | A path to the working directory of the action. This should be relative to the `$GITHUB_WORKSPACE`. | `.` |
 | `gh_rest_api_base_url` | The base URL for the GitHub REST API. This is useful for GitHub Enterprise users.</br>Note, `/api/v3` will be appended to this value if it does not already exist. See the note [here](https://docs.github.com/en/enterprise-server@3.10/rest/quickstart?apiVersion=2022-11-28&tool=curl#using-curl-commands-in-github-actions). | `https://api.github.com` |
 | `acceptable_conclusions` | A comma-separated list of acceptable statuses. If any of these statuses are present, the action will not fail.</br></br>See the [GitHub REST API documentation](https://docs.github.com/en/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run), specifically, the Response schema's "conclusion" property's `enum` values, for a complete list of supported values (excluding `null`). | `success` |
+| `fail_fast` | If set to true, the action will fail as soon as a check fails. If set to false (default), the action will wait for all checks to complete before failing. | `False` |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
     description: 'A comma-separated list of acceptable conclusions. If any of these conclusions are present, the action will not fail.'
     required: false
     default: 'success'
+  fail_fast:
+    description: 'If set to true, the action will fail as soon as a check fails. If set to false (default), the action will wait for all checks to complete before failing.'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: 'A path to the working directory of the action. This should be relative to the $GITHUB_WORKSPACE.'
     required: false
     default: '.'
+  acceptable_conclusions:
+    description: 'A comma-separated list of acceptable conclusions. If any of these conclusions are present, the action will not fail.'
+    required: false
+    default: 'success'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,13 @@ unprotect () {
         y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
             if [ -n "${PUSH_PROTECTED_CHANGED_BRANCH}" ] && [ -n "${PUSH_PROTECTED_PROTECTED_BRANCH}" ]; then
                 echo -e "\nRemove '${INPUT_BRANCH}' pull request review protection ..."
-                push-action --token "${INPUT_TOKEN}" --ref "${INPUT_BRANCH}" --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" -- unprotect_reviews
+
+                push-action \
+                    --token "${INPUT_TOKEN}" \
+                    --ref "${INPUT_BRANCH}" \
+                    --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" \
+                    -- unprotect_reviews
+
                 echo "Remove '${INPUT_BRANCH}' pull request review protection ... DONE!"
             fi
             ;;
@@ -33,7 +39,13 @@ protect () {
         y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
             if [ -n "${PUSH_PROTECTED_CHANGED_BRANCH}" ] && [ -n "${PUSH_PROTECTED_PROTECTED_BRANCH}" ]; then
                 echo -e "\nRe-add '${INPUT_BRANCH}' pull request review protection ..."
-                push-action --token "${INPUT_TOKEN}" --ref "${INPUT_BRANCH}" --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" -- protect_reviews
+
+                push-action \
+                    --token "${INPUT_TOKEN}" \
+                    --ref "${INPUT_BRANCH}" \
+                    --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" \
+                    -- protect_reviews
+
                 echo "Re-add '${INPUT_BRANCH}' pull request review protection ... DONE!"
             fi
             ;;
@@ -49,14 +61,38 @@ wait_for_checks() {
         echo -e "\nWaiting for status checks to finish for '${PUSH_PROTECTED_TEMPORARY_BRANCH}' ..."
         # Sleep for 5 seconds to let the workflows start
         sleep ${INPUT_SLEEP}
-        push-action --token "${INPUT_TOKEN}" --ref "${INPUT_BRANCH}" --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" --wait-timeout "${INPUT_TIMEOUT}" --wait-interval "${INPUT_INTERVAL}" -- wait_for_checks
+
+        ACCEPTABLE_CONCLUSIONS=()
+        if [ -n "${INPUT_ACCEPTABLE_CONCLUSIONS}" ]; then
+            while IFS="," read -ra CONCLUSIONS; do
+                for CONCLUSION in "${CONCLUSIONS[@]}"; do
+                    ACCEPTABLE_CONCLUSIONS+=(--acceptable-conclusion="${CONCLUSION}")
+                done
+            done <<< "${INPUT_ACCEPTABLE_CONCLUSIONS}"
+        fi
+
+        push-action \
+            --token "${INPUT_TOKEN}" \
+            --ref "${INPUT_BRANCH}" \
+            --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" \
+            --wait-timeout "${INPUT_TIMEOUT}" \
+            --wait-interval "${INPUT_INTERVAL}"\
+            "${ACCEPTABLE_CONCLUSIONS[@]}" \
+            -- wait_for_checks
+
         echo "Waiting for status checks to finish for '${PUSH_PROTECTED_TEMPORARY_BRANCH}' ... DONE!"
     fi
 }
 remove_remote_temp_branch() {
     if [ -n "${PUSH_PROTECTED_CHANGED_BRANCH}" ] && [ -n "${PUSH_PROTECTED_PROTECTED_BRANCH}" ]; then
         echo -e "\nRemoving temporary branch '${PUSH_PROTECTED_TEMPORARY_BRANCH}' ..."
-        push-action --token "${INPUT_TOKEN}" --ref "${INPUT_BRANCH}" --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" -- remove_temp_branch
+
+        push-action \
+            --token "${INPUT_TOKEN}" \
+            --ref "${INPUT_BRANCH}" \
+            --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" \
+            -- remove_temp_branch
+
         echo "Removing temporary branch '${PUSH_PROTECTED_TEMPORARY_BRANCH}' ... DONE!"
     fi
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,13 +66,11 @@ wait_for_checks() {
         sleep ${INPUT_SLEEP}
 
         ACCEPTABLE_CONCLUSIONS=()
-        if [ -n "${INPUT_ACCEPTABLE_CONCLUSIONS}" ]; then
-            while IFS="," read -ra CONCLUSIONS; do
-                for CONCLUSION in "${CONCLUSIONS[@]}"; do
-                    ACCEPTABLE_CONCLUSIONS+=(--acceptable-conclusion="${CONCLUSION}")
-                done
-            done <<< "${INPUT_ACCEPTABLE_CONCLUSIONS}"
-        fi
+        while IFS="," read -ra CONCLUSIONS; do
+            for CONCLUSION in "${CONCLUSIONS[@]}"; do
+                ACCEPTABLE_CONCLUSIONS+=(--acceptable-conclusion="${CONCLUSION}")
+            done
+        done <<< "${INPUT_ACCEPTABLE_CONCLUSIONS}"
 
         push-action ${FAIL_FAST} \
             --token "${INPUT_TOKEN}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,7 +74,7 @@ wait_for_checks() {
             done <<< "${INPUT_ACCEPTABLE_CONCLUSIONS}"
         fi
 
-        push-action \
+        push-action ${FAIL_FAST} \
             --token "${INPUT_TOKEN}" \
             --ref "${INPUT_BRANCH}" \
             --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" \
@@ -216,6 +216,19 @@ case ${INPUT_TAGS} in
         ;;
     *)
         echo -e "\nNon-valid input for 'tags': ${INPUT_TAGS}. Will use default (false)."
+        ;;
+esac
+
+# --fail-fast
+case ${INPUT_FAIL_FAST} in
+    y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
+        echo -e "\nWill fail fast (fail as soon as any check fails)!"
+        FAIL_FAST="--fail-fast"
+        ;;
+    n | N | no | No | NO | false | False | FALSE | off | Off | OFF)
+        ;;
+    *)
+        echo -e "\nNon-valid input for 'fail_fast': ${INPUT_FAIL_FAST}. Will use default (false)."
         ;;
 esac
 

--- a/push_action/run.py
+++ b/push_action/run.py
@@ -336,11 +336,12 @@ def main() -> None:
 
     fail = ""
     try:
-        IN_MEMORY_CACHE["acceptable_conclusions"] = validate_conclusions(
-            IN_MEMORY_CACHE["args"].acceptable_conclusion
-        )
-
         if IN_MEMORY_CACHE["args"].ACTION == "wait_for_checks":
+            # Ensure that the acceptable conclusions are valid
+            IN_MEMORY_CACHE["acceptable_conclusions"] = validate_conclusions(
+                IN_MEMORY_CACHE["args"].acceptable_conclusion
+            )
+
             wait()
         elif IN_MEMORY_CACHE["args"].ACTION == "remove_temp_branch":
             remove_branch(IN_MEMORY_CACHE["args"].temp_branch)

--- a/push_action/run.py
+++ b/push_action/run.py
@@ -86,6 +86,16 @@ Configuration:
                     not in IN_MEMORY_CACHE["acceptable_conclusions"]
                 ):
                     # Job is completed unsuccessfully
+                    if IN_MEMORY_CACHE["args"].fail_fast:
+                        # Fail fast
+                        raise RuntimeError(
+                            f"Required check {job['name']} completed with conclusion "
+                            f"{job['conclusion']!r} (not part of the acceptable "
+                            "conclusions: "
+                            f"{', '.join(IN_MEMORY_CACHE['acceptable_conclusions'])})."
+                            f"\n{job}"
+                        )
+
                     unsuccessful_jobs.append(job)
 
         if not actions_required:
@@ -297,7 +307,14 @@ def main() -> None:
             "successful"
         ),
         action="append",
-        default=["success"],
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help=(
+            "Whether or not to fail fast (i.e., exit immediately) if one of the "
+            "checks fails. Only valid with the wait_for_checks action."
+        ),
     )
     parser.add_argument(
         "ACTION",

--- a/push_action/run.py
+++ b/push_action/run.py
@@ -82,9 +82,9 @@ Configuration:
             # All jobs are completed
             print("All required GitHub Actions jobs complete!", flush=True)
             unsuccessful_jobs = [
-                job_run
-                for job_run in actions_required
-                if job_run.get("conclusion", "")
+                job
+                for job in actions_required
+                if job.get("conclusion", "")
                 not in IN_MEMORY_CACHE["acceptable_conclusions"]
             ]
             break
@@ -95,14 +95,14 @@ Configuration:
         )
         sleep(IN_MEMORY_CACHE["args"].wait_interval)
 
-        run_ids = {_["run_id"] for _ in actions_required}
+        run_ids = {job["run_id"] for job in actions_required}
         actions_required = []
         for run in run_ids:
             actions_required.extend(
                 [
-                    _
-                    for _ in get_workflow_run_jobs(run, new_request=True)
-                    if _["name"] in required_statuses and _["status"] != "completed"
+                    job
+                    for job in get_workflow_run_jobs(run, new_request=True)
+                    if job["name"] in required_statuses and job["status"] != "completed"
                 ]
             )
 

--- a/push_action/run.py
+++ b/push_action/run.py
@@ -83,7 +83,7 @@ Configuration:
             print("All required GitHub Actions jobs complete!", flush=True)
             unsuccessful_jobs = [
                 job
-                for job in actions_required
+                for job in get_required_actions(required_statuses, new_request=True)
                 if job.get("conclusion", "")
                 not in IN_MEMORY_CACHE["acceptable_conclusions"]
             ]

--- a/push_action/utils.py
+++ b/push_action/utils.py
@@ -19,7 +19,7 @@ import requests
 from push_action.cache import IN_MEMORY_CACHE
 
 if TYPE_CHECKING:
-    from typing import Callable, List, Optional, Union
+    from typing import Callable, List, Union
 
 
 REQUEST_TIMEOUT = 10  # in seconds

--- a/push_action/validate.py
+++ b/push_action/validate.py
@@ -39,6 +39,9 @@ def validate_conclusions(conclusions: list[str]) -> list[str]:
             "No conclusions supplied - at least one is required (default: 'success')."
         )
 
+    # Remove redundant entries and conform to lowercase
+    conclusions = list(set(conclusion.lower() for conclusion in conclusions))
+
     for conclusion in conclusions:
         invalid_conclusions: list[str] = []
         if conclusion not in VALID_CONCLUSIONS:

--- a/push_action/validate.py
+++ b/push_action/validate.py
@@ -1,0 +1,42 @@
+"""Validate inputs."""
+from __future__ import annotations
+
+
+VALID_CONCLUSIONS = [
+    "action_required",
+    "cancelled",
+    "failure",
+    "neutral",
+    "skipped",
+    "success",
+    "timed_out",
+]
+"""List of valid GitHub Actions workflow job run conclusions.
+This is taken from
+https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2022-11-28#get-a-job-for-a-workflow-run
+as of 30.10.2023.
+"""
+
+
+def validate_conclusions(conclusions: list[str]) -> list[str]:
+    """Validate the conclusions.
+
+    I.e., ensure they are valid GitHub Actions workflow job run conclusions.
+    """
+    if not conclusions:
+        raise ValueError(
+            "No conclusions supplied - at least one is required (default: 'success')."
+        )
+
+    for conclusion in conclusions:
+        invalid_conclusions: list[str] = []
+        if conclusion not in VALID_CONCLUSIONS:
+            invalid_conclusions.append(conclusion)
+
+    if invalid_conclusions:
+        return [
+            f"Invalid supplied conclusions: {invalid_conclusions}. "
+            f"Valid conclusions are: {VALID_CONCLUSIONS}"
+        ]
+
+    return conclusions


### PR DESCRIPTION
Closes #149 

Add `acceptable_conclusions` as an action input parameter.
It is a comma-separated list of acceptable conclusions for _all_ status checks.

Update the CI jobs to test the parameter.

Should also close #153 