### PR TITLE
Reinstate, but deprecate, the 'sleep' input

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -64,7 +64,6 @@ jobs:
         token: '${{ secrets.GITHUB_TOKEN }}'
         branch: not_protected
         unprotect_reviews: false
-        sleep: 5
 
     - name: Check tags (local)
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -64,6 +64,7 @@ jobs:
         token: '${{ secrets.GITHUB_TOKEN }}'
         branch: not_protected
         unprotect_reviews: false
+        sleep: 5
 
     - name: Check tags (local)
       run: |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ All input names in **bold** are _required_.
 | `acceptable_conclusions` | A comma-separated list of acceptable statuses. If any of these statuses are present, the action will not fail.</br></br>See the [GitHub REST API documentation](https://docs.github.com/en/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run), specifically, the Response schema's "conclusion" property's `enum` values, for a complete list of supported values (excluding `null`). | `success` |
 | `fail_fast` | If set to true, the action will fail as soon as a check fails. If set to false (default), the action will wait for all checks to complete before failing. | `False` |
 
+### Deprecated inputs
+
+| Name | Replaced by | Deprecated since |
+|:---:|:---:|:---:|
+| `sleep` | `pre_sleep` | v2.15.0 |
+
 ## License
 
 All files in this repository is licensed under the [MIT License](LICENSE) and copyright &copy; Casper Welzel Andersen.

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,12 @@ inputs:
     description: 'If set to true, the action will fail as soon as a check fails. If set to false (default), the action will wait for all checks to complete before failing.'
     required: false
     default: 'false'
+
+  # DEPRECATED
+  sleep:
+    description: "DEPRECATED! Use 'pre_sleep'. Time (in seconds) the action should wait until it will start 'waiting' and check the list of running actions/checks. This should be an appropriate number to let the checks start up"
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,7 @@ esac
 set -e
 
 if [ -n "${INPUT_SLEEP}" ]; then
-    deprecation_message="The 'sleep' input is deprecated. Please use 'pre_sleep' instead."
-    echo "${deprecation_message}"
-    echo "::warning title=Deprecated input::${deprecation_message}"
+    echo "::warning title=Deprecated input::The 'sleep' input is deprecated. Please use 'pre_sleep' instead."
     if [ -z "${INPUT_PRE_SLEEP}" ] || [ "${INPUT_PRE_SLEEP}" == "5" ]; then
         # If `pre_sleep` is not defined, or is the default value, use the deprecated `sleep` input value
         INPUT_PRE_SLEEP=${INPUT_SLEEP}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,16 @@ esac
 
 set -e
 
+if [ -n "${INPUT_SLEEP}" ]; then
+    deprecation_message="The 'sleep' input is deprecated. Please use 'pre_sleep' instead."
+    echo "${deprecation_message}"
+    echo "::warning title=Deprecated input::${deprecation_message}"
+    if [ -z "${INPUT_PRE_SLEEP}" ] || [ "${INPUT_PRE_SLEEP}" == "5" ]; then
+        # If `pre_sleep` is not defined, or is the default value, use the deprecated `sleep` input value
+        INPUT_PRE_SLEEP=${INPUT_SLEEP}
+    fi
+fi
+
 # Utility functions
 ere_quote() {
     sed 's/[][\.|$(){}?+*^]/\\&/g' <<< "$*"


### PR DESCRIPTION
Fixes #209 

A (deprecation) warning is emitted if the `sleep` input is specified.

The value will still be used, but **only if** `pre_sleep` is either not defined or is equal to its default value.
`sleep`'s default value has been reset to an empty string (used to be `'5'`).

---

From a test CI run with `sleep` set, it is seen that the warning will be shown in the CI workflow summary:
![image](https://github.com/CasperWA/push-protected/assets/43357585/09d91e04-1cd0-453e-8152-ae706aff1434)

Furthermore, the warning will be shown in the workflow:
![image](https://github.com/CasperWA/push-protected/assets/43357585/1fd3f6c7-b977-42c4-bdcf-a0dd06243cce)
