### PR TITLE
fix: restore branch protections in cleanup trap on push failure

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -151,6 +151,16 @@ jobs:
         echo "Outcome: ${{ steps.push_no_force.outcome }} (not 'failure'), Conclusion: ${{ steps.push_no_force.conclusion }} (not 'success')"
         exit 1
 
+    - name: Verify branch protections were restored after push failure
+      run: |
+        response=$(curl --silent \
+          --header "Authorization: Bearer ${{ secrets.CI_PUSH_TO_PROTECTED_BRANCH }}" \
+          --header "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${GITHUB_REPOSITORY}/branches/protected/protection/required_pull_request_reviews")
+        echo "Protection response: ${response}"
+        # If required_pull_request_reviews is present, protections were restored
+        echo "${response}" | python3 -c "import sys, json; d = json.load(sys.stdin); sys.exit(0 if 'required_approving_review_count' in d else 1)"
+
     - name: Push using `--force` (should succeed)
       uses: ./
       with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -151,6 +151,10 @@ cleanup() {
     exit ${EXIT_CODE}
 }
 
+# Allow this file to be sourced (e.g. in unit tests) to load function
+# definitions without registering the trap or running the main body.
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
+
 # Trap exit command and cleanup
 trap cleanup EXIT
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,10 @@ unprotect () {
                     --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" \
                     -- unprotect_reviews
 
+                # Track that protections have been removed so cleanup can restore them
+                # if the push fails before protect() is called.
+                PUSH_PROTECTED_REVIEWS_REMOVED=yes
+
                 echo "Remove '${INPUT_BRANCH}' pull request review protection ... DONE!"
             fi
             ;;
@@ -56,6 +60,9 @@ protect () {
                     --ref "${INPUT_BRANCH}" \
                     --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" \
                     -- protect_reviews
+
+                # Protections successfully restored; clear the flag.
+                PUSH_PROTECTED_REVIEWS_REMOVED=
 
                 echo "Re-add '${INPUT_BRANCH}' pull request review protection ... DONE!"
             fi
@@ -124,6 +131,19 @@ push_to_target() {
 cleanup() {
     # Get exit code of latest command
     EXIT_CODE=$?
+
+    # Restore pull request review protections if they were removed but not yet
+    # restored (e.g. because the push step failed).
+    if [ -n "${PUSH_PROTECTED_REVIEWS_REMOVED}" ]; then
+        echo -e "\n::warning::Push failed after removing branch protections. Attempting to restore '${INPUT_BRANCH}' pull request review protection ..."
+        push-action \
+            --token "${INPUT_TOKEN}" \
+            --ref "${INPUT_BRANCH}" \
+            --temp-branch "${PUSH_PROTECTED_TEMPORARY_BRANCH}" \
+            -- protect_reviews \
+            && echo "Restored '${INPUT_BRANCH}' pull request review protection after failure." \
+            || echo "::error::Failed to restore pull request review protection for '${INPUT_BRANCH}'. Please restore the branch protection rules manually before merging any pull requests."
+    fi
 
     # Cleanup - Remove temporary branch
     remove_remote_temp_branch


### PR DESCRIPTION
## Summary

Fixes #302

When `unprotect_reviews: true` is set and the push step fails (e.g. due to permissions issues, a branch update race condition, or a rejected push), branch protections were left **disabled** because `protect()` was only ever called in the happy-path flow after a successful push.

## Root cause

`entrypoint.sh` calls `unprotect` → `push_to_target` → `protect` in sequence. The `cleanup()` EXIT trap only removed the temporary branch. If `push_to_target` failed (causing bash `set -e` to trigger EXIT), the trap ran but skipped `protect()`.

## Changes

- Introduces a `PUSH_PROTECTED_REVIEWS_REMOVED` flag that is set to `yes` after `unprotect_reviews` succeeds and cleared after `protect_reviews` succeeds.
- Extends the `cleanup()` EXIT trap to call `protect_reviews` when the flag is still set, ensuring protections are **always** restored regardless of whether the push succeeded or failed.
- On failure, logs a GitHub Actions `::warning::` when restoring in the error path and a loud `::error::` with manual remediation guidance if restoration itself fails.

## Acceptance criteria (from issue)

- ✅ With `unprotect_reviews=true`, protections are restored after a **successful** push (unchanged behaviour; flag is cleared before exit).
- ✅ With `unprotect_reviews=true`, protections are also restored after any **push failure** (new behaviour; cleanup trap handles it).